### PR TITLE
Fix issue with Prefetch when the field would have been in select_rela

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
   rev: v0.1.0
   hooks:
     - id: ruff
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.6.4
+  hooks:
+    - id: isort
+      args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.1.0
+  hooks:
+    - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.isort]
+profile = "black"
+include_trailing_comma = true
+
+known_future_library = ["future", "__future__"]
+known_django = ["django"]
+import_heading_stdlib = "Standard libraries"
+import_heading_django = "Django"
+known_restframework = ["rest_framework"]
+import_heading_future = "Future"
+import_heading_restframework = "Rest Framework"
+import_heading_thirdparty = "Third party"
+import_heading_firstparty = "drf-serializer-prefetch"
+import_heading_localfolder = "Local"
+default_section = "FIRSTPARTY"
+sections = [
+  "FUTURE",
+  "STDLIB",
+  "DJANGO",
+  "RESTFRAMEWORK",
+  "THIRDPARTY",
+  "FIRSTPARTY",
+  "LOCALFOLDER",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django>=5.0a1
 djangorestframework>=3.12
 coverage
 tox
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-django>=3.2.0
+django>=5.0a1
 djangorestframework>=3.12
 coverage
+tox

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+# Standard libraries
 import os
 import sys
 
+# Django
 from django.core.management import execute_from_command_line
 
 

--- a/serializer_prefetch/__init__.py
+++ b/serializer_prefetch/__init__.py
@@ -1,3 +1,4 @@
+# Local
 from .base import PrefetchingListSerializer, PrefetchingSerializerMixin
 
 __all__ = (PrefetchingListSerializer, PrefetchingSerializerMixin)

--- a/serializer_prefetch/base.py
+++ b/serializer_prefetch/base.py
@@ -274,13 +274,6 @@ class PrefetchingLogicMixin:
 
         return computed_related
 
-    def _get_model_from_serializer(self, serializer):
-        with suppress(AttributeError):
-            return serializer.Meta.model
-
-        with suppress(AttributeError):
-            return serializer.child.Meta.model
-
     @staticmethod
     def _get_joined_prefetch(current_relation: Prefetch | str, item: Prefetch | str):
         if isinstance(item, str):

--- a/serializer_prefetch/base.py
+++ b/serializer_prefetch/base.py
@@ -1,12 +1,10 @@
 import copy
-from contextlib import suppress
 from collections.abc import Iterable
 
 from django.db.models import Model, QuerySet, prefetch_related_objects, Prefetch
 from django.utils.translation import gettext as _
 from rest_framework.fields import empty
 from rest_framework import serializers
-from rest_framework.utils import model_meta
 
 
 class PrefetchingLogicMixin:

--- a/serializer_prefetch/base.py
+++ b/serializer_prefetch/base.py
@@ -1,10 +1,14 @@
+# Standard libraries
 import copy
 from collections.abc import Iterable
 
-from django.db.models import Model, QuerySet, prefetch_related_objects, Prefetch
+# Django
+from django.db.models import Model, Prefetch, QuerySet, prefetch_related_objects
 from django.utils.translation import gettext as _
-from rest_framework.fields import empty
+
+# Rest Framework
 from rest_framework import serializers
+from rest_framework.fields import empty
 
 
 class PrefetchingLogicMixin:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
+# Standard libraries
 from pathlib import Path
-from setuptools import setup, find_packages
 
+# drf-serializer-prefetch
+from setuptools import find_packages, setup
 
 VERSION = "1.1.3"
 DESCRIPTION = "An automatic prefetcher for django-rest-framework."

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+# Django
 from django.db import models
 
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,8 +1,9 @@
+# Rest Framework
 from rest_framework import serializers
 
+# drf-serializer-prefetch
 from serializer_prefetch import PrefetchingSerializerMixin
-
-from tests.models import Continent, Pizza, Topping, Country
+from tests.models import Continent, Country, Pizza, Topping
 
 
 class ToppingSerializer(PrefetchingSerializerMixin, serializers.ModelSerializer):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,7 @@
+# Future
 from __future__ import annotations
 
+# Standard libraries
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,12 +1,16 @@
+# Standard libraries
 from unittest import skip
+
+# Django
 from django.db.models import Prefetch
 from django.test import TestCase
 
+# Rest Framework
 from rest_framework import serializers
 
+# drf-serializer-prefetch
 from serializer_prefetch import PrefetchingSerializerMixin
-
-from tests.models import Continent, Pizza, Topping, Country
+from tests.models import Continent, Country, Pizza, Topping
 from tests.serializers import (
     ContinentSerializer,
     CountrySerializer,

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,5 +1,5 @@
 # Standard libraries
-from unittest import skip
+# from unittest import skip
 
 # Django
 from django.db.models import Prefetch
@@ -12,7 +12,7 @@ from rest_framework import serializers
 from serializer_prefetch import PrefetchingSerializerMixin
 from tests.models import Continent, Country, Pizza, Topping
 from tests.serializers import (
-    ContinentSerializer,
+    # ContinentSerializer,
     CountrySerializer,
     PizzaSerializer,
     ToppingSerializer,
@@ -225,115 +225,115 @@ class ConditionsTestCase(TestCase):
             ],
         )
 
-    @skip("This test only passes on Django 5.0 and above. Unskip when it's released")
-    def test_prefetch_object_is_passed_with_depth_2(self):
-        pizza = Pizza.objects.create(
-            label="For this test only.",
-            provenance=Country.objects.create(
-                label="France",
-                continent=Continent.objects.get_or_create(label="Mistyped Urope")[0],
-            ),
-        )
-        Topping.objects.get_or_create(
-            label="Parmesan",
-            origin=Country.objects.get_or_create(
-                label="Italy",
-                continent=Continent.objects.get_or_create(label="Europe")[0],
-            )[0],
-            pizza=pizza,
-        )
-        Topping.objects.get_or_create(
-            label="Paneer",
-            origin=Country.objects.get_or_create(
-                label="Some South Asian Country",
-                continent=Continent.objects.get_or_create(label="Asia")[0],
-            )[0],
-            pizza=pizza,
-        )
-        Topping.objects.get_or_create(
-            label="Other Thing",
-            origin=Country.objects.get_or_create(
-                label="Canada",
-                continent=Continent.objects.get_or_create(label="America")[0],
-            )[0],
-            pizza=pizza,
-        )
+    # @skip("This test only passes on Django 5.0 and above. Unskip when it's released")
+    # def test_prefetch_object_is_passed_with_depth_2(self):
+    #     pizza = Pizza.objects.create(
+    #         label="For this test only.",
+    #         provenance=Country.objects.create(
+    #             label="France",
+    #             continent=Continent.objects.get_or_create(label="Mistyped Urope")[0],
+    #         ),
+    #     )
+    #     Topping.objects.get_or_create(
+    #         label="Parmesan",
+    #         origin=Country.objects.get_or_create(
+    #             label="Italy",
+    #             continent=Continent.objects.get_or_create(label="Europe")[0],
+    #         )[0],
+    #         pizza=pizza,
+    #     )
+    #     Topping.objects.get_or_create(
+    #         label="Paneer",
+    #         origin=Country.objects.get_or_create(
+    #             label="Some South Asian Country",
+    #             continent=Continent.objects.get_or_create(label="Asia")[0],
+    #         )[0],
+    #         pizza=pizza,
+    #     )
+    #     Topping.objects.get_or_create(
+    #         label="Other Thing",
+    #         origin=Country.objects.get_or_create(
+    #             label="Canada",
+    #             continent=Continent.objects.get_or_create(label="America")[0],
+    #         )[0],
+    #         pizza=pizza,
+    #     )
 
-        class CountrySerializer(
-            PrefetchingSerializerMixin, serializers.ModelSerializer
-        ):
-            prefetch_related = (
-                Prefetch(
-                    "continent",
-                    queryset=Continent.objects.filter(
-                        label__in=("Europe", "America")
-                    ),  # noqa: E501
-                    to_attr="continent_eu",
-                ),
-            )
+    #     class CountrySerializer(
+    #         PrefetchingSerializerMixin, serializers.ModelSerializer
+    #     ):
+    #         prefetch_related = (
+    #             Prefetch(
+    #                 "continent",
+    #                 queryset=Continent.objects.filter(
+    #                     label__in=("Europe", "America")
+    #                 ),  # noqa: E501
+    #                 to_attr="continent_eu",
+    #             ),
+    #         )
 
-            continent = ContinentSerializer(source="continent_eu")
+    #         continent = ContinentSerializer(source="continent_eu")
 
-            class Meta:
-                model = Country
-                fields = ("label", "continent")
+    #         class Meta:
+    #             model = Country
+    #             fields = ("label", "continent")
 
-        class ToppingSerializer(
-            PrefetchingSerializerMixin, serializers.ModelSerializer
-        ):
-            prefetch_related = (
-                Prefetch(
-                    "origin",
-                    queryset=Country.objects.filter(continent__label="Europe"),
-                    to_attr="origin_eu",
-                ),
-            )
+    #     class ToppingSerializer(
+    #         PrefetchingSerializerMixin, serializers.ModelSerializer
+    #     ):
+    #         prefetch_related = (
+    #             Prefetch(
+    #                 "origin",
+    #                 queryset=Country.objects.filter(continent__label="Europe"),
+    #                 to_attr="origin_eu",
+    #             ),
+    #         )
 
-            origin = CountrySerializer(source="origin_eu")
+    #         origin = CountrySerializer(source="origin_eu")
 
-            class Meta:
-                model = Topping
-                fields = ("label", "origin")
+    #         class Meta:
+    #             model = Topping
+    #             fields = ("label", "origin")
 
-        class PizzaSerializer(
-            PrefetchingSerializerMixin, serializers.ModelSerializer
-        ):  # noqa: E501
-            prefetch_related = ("toppings__origin",)
+    #     class PizzaSerializer(
+    #         PrefetchingSerializerMixin, serializers.ModelSerializer
+    #     ):  # noqa: E501
+    #         prefetch_related = ("toppings__origin",)
 
-            toppings = ToppingSerializer(many=True)
+    #         toppings = ToppingSerializer(many=True)
 
-            provenance = CountrySerializer()
+    #         provenance = CountrySerializer()
 
-            class Meta:
-                model = Pizza
-                fields = ("label", "toppings", "provenance")
+    #         class Meta:
+    #             model = Pizza
+    #             fields = ("label", "toppings", "provenance")
 
-        pizzas = Pizza.objects.filter(id=pizza.pk)
-        serializer = PizzaSerializer(pizzas, many=True)
+    #     pizzas = Pizza.objects.filter(id=pizza.pk)
+    #     serializer = PizzaSerializer(pizzas, many=True)
 
-        with self.assertNumQueries(6):
-            data = serializer.data
+    #     with self.assertNumQueries(6):
+    #         data = serializer.data
 
-        self.assertEqual(
-            data,
-            [
-                {
-                    "label": "For this test only.",
-                    "toppings": [
-                        {
-                            "label": "Parmesan",
-                            "origin": {
-                                "label": "Italy",
-                                "continent": {"label": "Europe"},
-                            },
-                        },
-                        {"label": "Paneer", "origin": None},
-                        {"label": "Other Thing", "origin": None},
-                    ],
-                    "provenance": {"label": "France", "continent": None},
-                },
-            ],
-        )
+    #     self.assertEqual(
+    #         data,
+    #         [
+    #             {
+    #                 "label": "For this test only.",
+    #                 "toppings": [
+    #                     {
+    #                         "label": "Parmesan",
+    #                         "origin": {
+    #                             "label": "Italy",
+    #                             "continent": {"label": "Europe"},
+    #                         },
+    #                     },
+    #                     {"label": "Paneer", "origin": None},
+    #                     {"label": "Other Thing", "origin": None},
+    #                 ],
+    #                 "provenance": {"label": "France", "continent": None},
+    #             },
+    #         ],
+    #     )
 
     def test_with_pagination(self):
         # Pagination returns a list instead of a Queryset

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,3 +1,4 @@
+from unittest import skip
 from django.db.models import Prefetch
 from django.test import TestCase
 
@@ -220,6 +221,7 @@ class ConditionsTestCase(TestCase):
             ],
         )
 
+    @skip("This test only passes on Django 5.0 and above. Unskip when it's released")
     def test_prefetch_object_is_passed_with_depth_2(self):
         pizza = Pizza.objects.create(
             label="For this test only.",

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,11 +1,14 @@
+from django.db.models import Prefetch
 from django.test import TestCase
 
 from rest_framework import serializers
 
 from serializer_prefetch import PrefetchingSerializerMixin
 
-from tests.models import Pizza, Topping, Country
+from tests.models import Continent, Pizza, Topping, Country
 from tests.serializers import (
+    ContinentSerializer,
+    CountrySerializer,
     PizzaSerializer,
     ToppingSerializer,
 )
@@ -114,217 +117,217 @@ class ConditionsTestCase(TestCase):
         pizzas = Pizza.objects.all()
         serializer = PizzaSerializer(pizzas, many=True)
 
-        # Note: the regular Serializer cannot handle auto prefetching,
-        # it has to be done manually
-        with self.assertNumQueries(3):
+        # Note: the regular Serializer can handle auto prefetching,
+        # however it will assume everything to be a prefetch since
+        # it cannot check with the field.
+        with self.assertNumQueries(2):
             serializer.data
 
-        class PizzaSerializer(PizzaSerializer):
-            additional_serializers = (
-                {"relation_and_field": "toppings", "serializer": ToppingSerializer()},
+        pizzas = [{"label": "test_label", "toppings": [{"label": "test_topping"}]}]
+        serializer = PizzaSerializer(pizzas, many=True)
+
+        with self.assertNumQueries(0):
+            serializer.data
+
+    def test_prefetch_object_is_passed_with_depth(self):
+        class ToppingSerializer(
+            PrefetchingSerializerMixin, serializers.ModelSerializer
+        ):
+            prefetch_related = (
+                Prefetch(
+                    "origin",
+                    queryset=Country.objects.filter(continent__label="Europe"),
+                    to_attr="origin_eu",
+                ),
             )
+
+            origin_eu = CountrySerializer()
+
+            class Meta:
+                model = Topping
+                fields = ("label", "origin_eu")
+
+        class PizzaSerializer(
+            PrefetchingSerializerMixin, serializers.ModelSerializer
+        ):  # noqa: E501
+            prefetch_related = (
+                Prefetch(
+                    "toppings",
+                    queryset=Topping.objects.filter(
+                        label__in=(
+                            "Provolone",
+                            "Cheddar",
+                            "Parmesan",
+                            "Mozzarella",
+                            "Paneer",
+                        )
+                    ),
+                    to_attr="cheese_toppings",
+                ),
+            )
+
+            cheese_toppings = ToppingSerializer(many=True)
+
+            class Meta:
+                model = Pizza
+                fields = ("label", "cheese_toppings")
+
+        pizza = Pizza.objects.create(
+            label="For this test only.",
+            provenance=Country.objects.create(label="France"),
+        )
+        Topping.objects.get_or_create(
+            label="Parmesan",
+            origin=Country.objects.get_or_create(
+                label="Italy",
+                continent=Continent.objects.get_or_create(label="Europe")[0],
+            )[0],
+            pizza=pizza,
+        )
+        Topping.objects.get_or_create(
+            label="Paneer",
+            origin=Country.objects.get_or_create(
+                label="Some South Asian Country",
+                continent=Continent.objects.get_or_create(label="Asia")[0],
+            )[0],
+            pizza=pizza,
+        )
 
         pizzas = Pizza.objects.all()
         serializer = PizzaSerializer(pizzas, many=True)
 
-        with self.assertNumQueries(2):
-            serializer.data
+        with self.assertNumQueries(3):
+            data = serializer.data
 
-    # TODO: Uncomment the tests once django bug https://code.djangoproject.com/ticket/34791
-    # is fixed
-    # def test_prefetch_object_is_passed_with_depth(self):
-    #     class ToppingSerializer(
-    #         PrefetchingSerializerMixin, serializers.ModelSerializer
-    #     ):
-    #         prefetch_related = (
-    #             Prefetch(
-    #                 "origin",
-    #                 queryset=Country.objects.filter(continent__label="Europe"),
-    #                 to_attr="origin_eu",
-    #             ),
-    #         )
+        self.assertEqual(
+            data,
+            [
+                {
+                    "label": "Hawaiian",
+                    "cheese_toppings": [],
+                },
+                {
+                    "label": "Pepperoni",
+                    "cheese_toppings": [],
+                },
+                {
+                    "label": "For this test only.",
+                    "cheese_toppings": [
+                        {"label": "Parmesan", "origin_eu": {"label": "Italy"}},
+                        {"label": "Paneer", "origin_eu": None},
+                    ],
+                },
+            ],
+        )
 
-    #         origin_eu = CountrySerializer()
+    def test_prefetch_object_is_passed_with_depth_2(self):
+        pizza = Pizza.objects.create(
+            label="For this test only.",
+            provenance=Country.objects.create(
+                label="France",
+                continent=Continent.objects.get_or_create(label="Mistyped Urope")[0],
+            ),
+        )
+        Topping.objects.get_or_create(
+            label="Parmesan",
+            origin=Country.objects.get_or_create(
+                label="Italy",
+                continent=Continent.objects.get_or_create(label="Europe")[0],
+            )[0],
+            pizza=pizza,
+        )
+        Topping.objects.get_or_create(
+            label="Paneer",
+            origin=Country.objects.get_or_create(
+                label="Some South Asian Country",
+                continent=Continent.objects.get_or_create(label="Asia")[0],
+            )[0],
+            pizza=pizza,
+        )
+        Topping.objects.get_or_create(
+            label="Other Thing",
+            origin=Country.objects.get_or_create(
+                label="Canada",
+                continent=Continent.objects.get_or_create(label="America")[0],
+            )[0],
+            pizza=pizza,
+        )
 
-    #         class Meta:
-    #             model = Topping
-    #             fields = ("label", "origin_eu")
+        class CountrySerializer(
+            PrefetchingSerializerMixin, serializers.ModelSerializer
+        ):
+            prefetch_related = (
+                Prefetch(
+                    "continent",
+                    queryset=Continent.objects.filter(
+                        label__in=("Europe", "America")
+                    ),  # noqa: E501
+                    to_attr="continent_eu",
+                ),
+            )
 
-    #     class PizzaSerializer(PrefetchingSerializerMixin, serializers.ModelSerializer):  # noqa: E501
-    #         prefetch_related = (
-    #             Prefetch(
-    #                 "toppings",
-    #                 queryset=Topping.objects.filter(
-    #                     label__in=(
-    #                         "Provolone",
-    #                         "Cheddar",
-    #                         "Parmesan",
-    #                         "Mozzarella",
-    #                         "Paneer",
-    #                     )
-    #                 ),
-    #                 to_attr="cheese_toppings",
-    #             ),
-    #         )
+            continent = ContinentSerializer(source="continent_eu")
 
-    #         cheese_toppings = ToppingSerializer(many=True)
+            class Meta:
+                model = Country
+                fields = ("label", "continent")
 
-    #         class Meta:
-    #             model = Pizza
-    #             fields = ("label", "cheese_toppings")
+        class ToppingSerializer(
+            PrefetchingSerializerMixin, serializers.ModelSerializer
+        ):
+            prefetch_related = (
+                Prefetch(
+                    "origin",
+                    queryset=Country.objects.filter(continent__label="Europe"),
+                    to_attr="origin_eu",
+                ),
+            )
 
-    #     pizza = Pizza.objects.create(
-    #         label="For this test only.",
-    #         provenance=Country.objects.create(label="France"),
-    #     )
-    #     Topping.objects.get_or_create(
-    #         label="Parmesan",
-    #         origin=Country.objects.get_or_create(
-    #             label="Italy",
-    #             continent=Continent.objects.get_or_create(label="Europe")[0],
-    #         )[0],
-    #         pizza=pizza,
-    #     )
-    #     Topping.objects.get_or_create(
-    #         label="Paneer",
-    #         origin=Country.objects.get_or_create(
-    #             label="Some South Asian Country",
-    #             continent=Continent.objects.get_or_create(label="Asia")[0],
-    #         )[0],
-    #         pizza=pizza,
-    #     )
+            origin = CountrySerializer(source="origin_eu")
 
-    #     pizzas = Pizza.objects.all()
-    #     serializer = PizzaSerializer(pizzas, many=True)
+            class Meta:
+                model = Topping
+                fields = ("label", "origin")
 
-    #     with self.assertNumQueries(5):
-    #         data = serializer.data
+        class PizzaSerializer(
+            PrefetchingSerializerMixin, serializers.ModelSerializer
+        ):  # noqa: E501
+            prefetch_related = ("toppings__origin",)
 
-    #     self.assertEqual(
-    #         data,
-    #         [
-    #             {
-    #                 "label": "Hawaiian",
-    #                 "cheese_toppings": [],
-    #             },
-    #             {
-    #                 "label": "Pepperoni",
-    #                 "cheese_toppings": [],
-    #             },
-    #             {
-    #                 "label": "For this test only.",
-    #                 "cheese_toppings": [
-    #                     {"label": "Parmesan", "origin_eu": {"label": "Italy"}},
-    #                     {"label": "Paneer", "origin_eu": None},
-    #                 ],
-    #             },
-    #         ],
-    #     )
+            toppings = ToppingSerializer(many=True)
 
-    # def test_prefetch_object_is_passed_with_depth_2(self):
-    #     class CountrySerializer(
-    #         PrefetchingSerializerMixin, serializers.ModelSerializer
-    #     ):
-    #         prefetch_related = (
-    #             Prefetch(
-    #                 "continent",
-    #                 queryset=Continent.objects.filter(label__in=("Europe", "America")),  # noqa: E501
-    #                 to_attr="continent_eu",
-    #             ),
-    #         )
+            provenance = CountrySerializer()
 
-    #         continent = ContinentSerializer(source="continent_eu")
+            class Meta:
+                model = Pizza
+                fields = ("label", "toppings", "provenance")
 
-    #         class Meta:
-    #             model = Country
-    #             fields = ("label", "continent")
+        pizzas = Pizza.objects.filter(id=pizza.pk)
+        serializer = PizzaSerializer(pizzas, many=True)
 
-    #     class ToppingSerializer(
-    #         PrefetchingSerializerMixin, serializers.ModelSerializer
-    #     ):
-    #         prefetch_related = (
-    #             Prefetch(
-    #                 "origin",
-    #                 queryset=Country.objects.filter(continent__label="Europe"),
-    #                 to_attr="origin_eu",
-    #             ),
-    #         )
+        with self.assertNumQueries(6):
+            data = serializer.data
 
-    #         origin = CountrySerializer(source="origin_eu")
-
-    #         class Meta:
-    #             model = Topping
-    #             fields = ("label", "origin")
-
-    #     class PizzaSerializer(PrefetchingSerializerMixin, serializers.ModelSerializer):  # noqa: E501
-    #         prefetch_related = ("toppings__origin",)
-
-    #         toppings = ToppingSerializer(many=True)
-
-    #         provenance = CountrySerializer()
-
-    #         class Meta:
-    #             model = Pizza
-    #             fields = ("label", "toppings", "provenance")
-
-    #     pizza = Pizza.objects.create(
-    #         label="For this test only.",
-    #         provenance=Country.objects.create(
-    #             label="France",
-    #             continent=Continent.objects.get_or_create(label="Mistyped Urope")[0],
-    #         ),
-    #     )
-    #     Topping.objects.get_or_create(
-    #         label="Parmesan",
-    #         origin=Country.objects.get_or_create(
-    #             label="Italy",
-    #             continent=Continent.objects.get_or_create(label="Europe")[0],
-    #         )[0],
-    #         pizza=pizza,
-    #     )
-    #     Topping.objects.get_or_create(
-    #         label="Paneer",
-    #         origin=Country.objects.get_or_create(
-    #             label="Some South Asian Country",
-    #             continent=Continent.objects.get_or_create(label="Asia")[0],
-    #         )[0],
-    #         pizza=pizza,
-    #     )
-    #     Topping.objects.get_or_create(
-    #         label="Other Thing",
-    #         origin=Country.objects.get_or_create(
-    #             label="Canada",
-    #             continent=Continent.objects.get_or_create(label="America")[0],
-    #         )[0],
-    #         pizza=pizza,
-    #     )
-
-    #     pizzas = Pizza.objects.filter(id=pizza.pk)
-    #     serializer = PizzaSerializer(pizzas, many=True)
-
-    #     with self.assertNumQueries(10):
-    #         data = serializer.data
-
-    #     self.assertEqual(
-    #         data,
-    #         [
-    #             {
-    #                 "label": "For this test only.",
-    #                 "toppings": [
-    #                     {
-    #                         "label": "Parmesan",
-    #                         "origin": {
-    #                             "label": "Italy",
-    #                             "continent": {"label": "Europe"},
-    #                         },
-    #                     },
-    #                     {"label": "Paneer", "origin": None},
-    #                     {"label": "Other Thing", "origin": None},
-    #                 ],
-    #                 "provenance": {"label": "France", "continent": None},
-    #             },
-    #         ],
-    #     )
+        self.assertEqual(
+            data,
+            [
+                {
+                    "label": "For this test only.",
+                    "toppings": [
+                        {
+                            "label": "Parmesan",
+                            "origin": {
+                                "label": "Italy",
+                                "continent": {"label": "Europe"},
+                            },
+                        },
+                        {"label": "Paneer", "origin": None},
+                        {"label": "Other Thing", "origin": None},
+                    ],
+                    "provenance": {"label": "France", "continent": None},
+                },
+            ],
+        )
 
     def test_with_pagination(self):
         # Pagination returns a list instead of a Queryset

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,8 +1,11 @@
+# Django
 from django.test import TestCase
 
+# Rest Framework
 from rest_framework import serializers
 
-from tests.models import Pizza, Topping, Country
+# drf-serializer-prefetch
+from tests.models import Country, Pizza, Topping
 from tests.serializers import PizzaSerializer
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,12 +1,14 @@
+# Django
 from django.db.models import Prefetch
 from django.test import TestCase
 
+# Rest Framework
 from rest_framework import serializers
 
+# drf-serializer-prefetch
 from serializer_prefetch import PrefetchingSerializerMixin
-
-from tests.models import Pizza, Topping, Country, Continent
-from tests.serializers import PizzaSerializer, ToppingSerializer, CountrySerializer
+from tests.models import Continent, Country, Pizza, Topping
+from tests.serializers import CountrySerializer, PizzaSerializer, ToppingSerializer
 
 
 class SerializersTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,8 @@
 requires =
     tox>=4
 env_list =
-       py39-{django32,django40}-{djangorestframework312,djangorestframework313,djangorestframework314},
-       {py310,py311}-{django32,django40}-{djangorestframework313,djangorestframework314},
-       {py39,py310,py311}-{django41,django42,django50}-{djangorestframework313,djangorestframework314},
-       {py310,py311}-latest,
+       {py39,py310,py311,py312}-{django42,django50}-{djangorestframework313,djangorestframework314},
+       {py310,py311,py312}-latest,
        lint
 
 
@@ -17,10 +15,8 @@ deps =
 [testenv]
 description = run unit tests
 deps = 
-    django32: django~=3.2.0
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
+    ; django50: Django>=5.0  Not released yet
     djangorestframework312: djangorestframework==3.12
     djangorestframework313: djangorestframework==3.13
     djangorestframework314: djangorestframework==3.14


### PR DESCRIPTION
- Fixes an issue with `Prefetch` in `prefetch_related` when the field would have been in `select_related` 
- Allows prefetching in non-model serializers when Model Serializers are used as its fields.
- Non model serializers now take into account the sub serializers and their prefetches